### PR TITLE
httpd: rebuild to fix config vars

### DIFF
--- a/Formula/httpd.rb
+++ b/Formula/httpd.rb
@@ -5,7 +5,7 @@ class Httpd < Formula
   mirror "https://downloads.apache.org/httpd/httpd-2.4.53.tar.bz2"
   sha256 "d0bbd1121a57b5f2a6ff92d7b96f8050c5a45d3f14db118f64979d525858db63"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   bottle do
     sha256 arm64_monterey: "e947b28cf796d63fe9c69fb27a890ab4068f915bd501fe1548cad816824fcf22"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Currently `apxs` is not giving the correct path for config variable `APU_CONFIG`
```bash
$ apxs -q APU_CONFIG       
/opt/homebrew/opt/apr-util/libexec/bin/apu-1-config
apxs:Error: /opt/homebrew/opt/apr-util/libexec/bin/apu-1-config not found!.
```

This breaks building PHP
https://github.com/shivammathur/homebrew-php/runs/6204315806?check_suite_focus=true#step:8:504

Reinstalling `httpd` from the source fixes the issue.
```bash
$ brew reinstall -s httpd
...
$ apxs -q APU_CONFIG
/opt/homebrew/opt/apr-util/bin/apu-1-config
```